### PR TITLE
fix: 一定の確率でテストに失敗する問題を解消

### DIFF
--- a/pkg/lookuptable/lookuptable.go
+++ b/pkg/lookuptable/lookuptable.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sort"
 )
 
 func LookupHost(root *Node, topic string) (string, uint16, error) {
@@ -107,7 +108,12 @@ func (n Node) String() string {
 	// HACK: 文字列生成処理の部分があまり効率の良くない実装になっている
 	result := fmt.Sprintf("{\"host\":\"%v\",\"port\":%v,\"children\":{", n.Host, n.Port)
 	counter := 1
-	for key, val := range n.Children {
+
+	// NOTE: go の map は range でイテレーションすると、実行するたびに順序が入れ替わるためキーをソートしている
+	childrenKey := keys(n.Children)
+	sort.Strings(childrenKey)
+	for _, key := range childrenKey {
+		val := n.Children[key]
 		if counter != len(n.Children) {
 			result += fmt.Sprintf("\"%v\":%v,", key, val)
 		} else {
@@ -117,6 +123,14 @@ func (n Node) String() string {
 	}
 	result += "}}"
 	return result
+}
+
+func keys(m map[string]*Node) []string {
+	ks := []string{}
+	for k, _ := range m {
+		ks = append(ks, k)
+	}
+	return ks
 }
 
 /** エラー構造体 **/

--- a/pkg/lookuptable/lookuptable_test.go
+++ b/pkg/lookuptable/lookuptable_test.go
@@ -390,3 +390,49 @@ func TestUpdateHost(t *testing.T) {
 		})
 	}
 }
+
+// NOTE: go の map は range でイテレーションすると、実行するたびに順序が入れ替わる
+//       Node 構造体を文字列に変換する関数がきちんとのことを考慮しているか確認するためのテスト
+func TestString(t *testing.T) {
+	type args struct {
+		node  *lookuptable.Node
+	}
+	tests := []struct {
+		name string
+		args args
+		time int  // 試行回数
+	}{
+		{
+			name: "Success 01",
+			args: args{
+				node: &lookuptable.Node{
+					Children: map[string]*lookuptable.Node{
+						"0": {
+							Children: map[string]*lookuptable.Node{},
+							Host:     "localhost",
+							Port:     5000,
+						},
+						"1": {
+							Children: map[string]*lookuptable.Node{},
+							Host:     "localhost",
+							Port:     5001,
+						},
+					},
+					Host: "localhost",
+					Port: 5000,
+				},
+			},
+			time: 1000,
+		},
+	}
+	for _, tt := range tests {
+		want := fmt.Sprint(tt.args.node)
+		for i:=0; i < tt.time; i++ {
+			t.Run(tt.name, func(t *testing.T) {
+				if fmt.Sprint(tt.args.node) != want {
+					t.Errorf("UpdateHost(); node = %v, expected %v", tt.args.node, want)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
go の map は range でイテレーションすると、実行するたびに順序が入れ替わるという仕様が原因だった